### PR TITLE
Add PermissionsBoundary support for app-wide IAM policy

### DIFF
--- a/docs/_docs/permissions_boundaries.md
+++ b/docs/_docs/permissions_boundaries.md
@@ -1,0 +1,25 @@
+---
+title: Permission Boundaries
+nav_order: 16.5
+---
+
+[Permissions Boundaries](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) can be used to set the maximum allowed permissions for users and roles. Jets supports attaching a Permissions Boundary to IAM roles created by the deploy role.
+
+## Setting a Permissions Boundary
+
+```ruby
+Jets.application.configure do |config|
+  config.permissions_boundary = "MyPermissionsBoundary"
+end
+```
+
+The resulting role will look something like this:
+
+```yaml
+IamRole:
+  Type: AWS::IAM::Role
+  Properties:
+    PermissionsBoundary: "arn:aws:iam:aws:policy/MyPermissionsBoundary"
+```
+
+{% include prev_next.md %}

--- a/lib/jets/resource/iam/application_role.rb
+++ b/lib/jets/resource/iam/application_role.rb
@@ -8,6 +8,8 @@ module Jets::Resource::Iam
 
       @managed_policy_definitions = Jets.config.managed_iam_policy # config.managed_iam_policy contains definitions
       @managed_policy_definitions = @managed_policy_definitions ? [@managed_policy_definitions].flatten : []
+
+      @permissions_boundary = Jets.config.permissions_boundary
     end
 
     def role_logical_id

--- a/lib/jets/resource/iam/base_role_definition.rb
+++ b/lib/jets/resource/iam/base_role_definition.rb
@@ -1,6 +1,6 @@
 module Jets::Resource::Iam
   module BaseRoleDefinition
-    attr_reader :policy_definitions, :managed_policy_definitions
+    attr_reader :policy_definitions, :managed_policy_definitions, :permissions_boundary
 
     def definition
       logical_id = role_logical_id
@@ -19,7 +19,7 @@ module Jets::Resource::Iam
                 principal: {service: ["lambda.amazonaws.com"]},
                 action: ["sts:AssumeRole"]}
               ]
-            }
+            },
           }
         }
       }
@@ -33,6 +33,10 @@ module Jets::Resource::Iam
         definition[logical_id][:properties][:managed_policy_arns] = managed_policy_arns
       end
 
+      unless permissions_boundary_arn.nil?
+        definition[logical_id][:properties][:permissions_boundary] = permissions_boundary_arn
+      end
+
       definition
     end
 
@@ -42,6 +46,10 @@ module Jets::Resource::Iam
 
     def managed_policy_arns
       ManagedPolicy.new(@managed_policy_definitions.flatten.uniq).arns
+    end
+
+    def permissions_boundary_arn
+      PermissionsBoundary.new(@permissions_boundary).arn
     end
   end
 end

--- a/lib/jets/resource/iam/permissions_boundary.rb
+++ b/lib/jets/resource/iam/permissions_boundary.rb
@@ -1,0 +1,22 @@
+module Jets::Resource::Iam
+  class PermissionsBoundary
+    extend Memoist
+
+    attr_reader :definition
+    def initialize(definition)
+      @definition = definition
+    end
+
+    def arn
+      standardize(definition)
+    end
+    memoize :arn # only process arn once
+
+    # AmazonEC2ReadOnlyAccess => arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+    def standardize(definition)
+      return definition if definition.nil? || definition.include?('iam::aws:policy')
+
+      "arn:aws:iam::aws:policy/#{definition}"
+    end
+  end
+end

--- a/spec/lib/jets/resource/iam/application_role_spec.rb
+++ b/spec/lib/jets/resource/iam/application_role_spec.rb
@@ -18,10 +18,10 @@ describe Jets::Resource::Iam::ApplicationRole do
 
         expect(role.definition[role.definition.keys.first]).to match(
           {type: 'AWS::IAM::Role',
-          properties: hash_including(
-            permissions_boundary: /arn:aws.*#{permissions_boundary}/,
-            managed_policy_arns: match_array(/arn:aws.*#{managed_iam_policy}/)
-          )}
+           properties: hash_including(
+             permissions_boundary: /arn:aws.*#{permissions_boundary}/,
+             managed_policy_arns: match_array(/arn:aws.*#{managed_iam_policy}/)
+           )}
         )
       end
     end

--- a/spec/lib/jets/resource/iam/application_role_spec.rb
+++ b/spec/lib/jets/resource/iam/application_role_spec.rb
@@ -1,0 +1,41 @@
+describe Jets::Resource::Iam::ApplicationRole do
+  let(:role) { Jets::Resource::Iam::ApplicationRole.new }
+  let(:managed_iam_policy) { "AWSCloudFormationReadOnlyAccess" }
+  let(:iam_policy) { nil }
+
+  before do
+    allow(Jets.config).to receive(:iam_policy).and_return(iam_policy)
+    allow(Jets.config).to receive(:managed_iam_policy).and_return(managed_iam_policy)
+    allow(Jets.config).to receive(:permissions_boundary).and_return(permissions_boundary)
+  end
+
+  describe "iam policy" do
+    context 'when a permissions boundary is set' do
+      let(:permissions_boundary) { "AWSEC2ReadOnlyAccess" }
+
+      it "expands correctly" do
+        # pp role.definition # uncomment to debug
+
+        expect(role.definition[role.definition.keys.first]).to match(
+          {type: 'AWS::IAM::Role',
+          properties: hash_including(
+            permissions_boundary: /arn:aws.*#{permissions_boundary}/,
+            managed_policy_arns: match_array(/arn:aws.*#{managed_iam_policy}/)
+          )}
+        )
+      end
+    end
+
+    context 'when a permissions boundary is not set' do
+      let(:permissions_boundary) { nil }
+
+      it "expands correctly" do
+        # pp role.definition # uncomment to debug
+
+        expect(role.definition[role.definition.keys.first][:properties]).not_to include(
+          :permissions_boundary
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/jets/resource/iam/permissions_boundary_spec.rb
+++ b/spec/lib/jets/resource/iam/permissions_boundary_spec.rb
@@ -1,0 +1,19 @@
+describe Jets::Resource::Iam::ManagedPolicy do
+  let(:permissions_boundary) do
+    Jets::Resource::Iam::PermissionsBoundary.new(definition)
+  end
+
+  context "single string" do
+    let(:definition) { "AmazonEC2ReadOnlyAccess" }
+    it "builds the resource definition" do
+      expect(permissions_boundary.arn).to eq "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+    end
+  end
+
+  context "full arn provided" do
+    let(:definition) { "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess" }
+    it "provides the iam managed policy arn" do
+      expect(permissions_boundary.arn).to eq "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+    end
+  end
+end


### PR DESCRIPTION
 This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Adds PermissionsBoundary support for the generated application IAM role.

## How to Test

For the new tests:
```
bundle exec rspec
```

You can test live by:
1. creating a managed IAM policy that will serve as the [permissions boundary](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html#access_policies_boundaries-delegate)
2. in `config/application.rb`, setting `config.permissions_boundary = "<policy name here>"`


## Version Changes

Would recommend a minor version change per Semantic Versioning, as this is a new backwards-compatible feature.
