### PR TITLE
Fix "@rendered not initialized" warning

### DIFF
--- a/lib/jets/controller/rendering.rb
+++ b/lib/jets/controller/rendering.rb
@@ -17,7 +17,7 @@ class Jets::Controller
     #  render json: {my: "data"}
     #  render text: "plain text"
     def render(options={}, rest={})
-      raise "DoubleRenderError" if @rendered
+      raise "DoubleRenderError" if defined?(@rendered) && @rendered
 
       if options.is_a?(Symbol) or options.is_a?(String)
         options = normalize_options(options, rest)


### PR DESCRIPTION
This is a 🐞 bug fix.

- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

I'm getting a warning about `@rendered` not being initialized:
```
/Users/joestein/.rbenv/versions/2.5.8/lib/ruby/gems/2.5.0/bundler/gems/jets-ea079b0e9f0e/lib/jets/controller/rendering.rb:20: warning: instance variable @rendered not initialized
```

## Version Changes

Patch change, if anything.

