### PR TITLE
Ensure we don't add darwin gems to the lambda layer

### DIFF
--- a/lib/jets/builders/ruby_packager.rb
+++ b/lib/jets/builders/ruby_packager.rb
@@ -62,7 +62,7 @@ module Jets::Builders
       Bundler.with_unbundled_env do
         sh(
           "cd #{cache_area} && " \
-          "env bundle install --path #{cache_area}/vendor/gems --without development test"
+          "env BUNDLE_FORCE_RUBY_PLATFORM=true bundle install --path #{cache_area}/vendor/gems --without development test"
         )
       end
 


### PR DESCRIPTION
Fix for `Could not find nokogiri-1.11.0 in any of the sources`