### PR TITLE
Do not transform customer-managed policy ARNs

### DIFF
--- a/lib/jets/resource/iam/managed_policy.rb
+++ b/lib/jets/resource/iam/managed_policy.rb
@@ -14,7 +14,7 @@ module Jets::Resource::Iam
 
     # AmazonEC2ReadOnlyAccess => arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
     def standardize(definition)
-      return definition if definition.include?('iam::aws:policy')
+      return definition if definition.match?(/iam::[0-9a-z]+:policy/i)
 
       "arn:aws:iam::aws:policy/#{definition}"
     end

--- a/spec/lib/jets/resource/iam/managed_policy_spec.rb
+++ b/spec/lib/jets/resource/iam/managed_policy_spec.rb
@@ -28,4 +28,13 @@ describe Jets::Resource::Iam::ManagedPolicy do
       ]
     end
   end
+
+  context "customer-managed policy" do
+    let(:definitions) { ["arn:aws:iam::1828372:policy/MyCustomerManagedPolicy"] }
+    it "provides the iam managed policy arn" do
+      expect(managed_policy.arns).to eq [
+        "arn:aws:iam::1828372:policy/MyCustomerManagedPolicy",
+      ]
+    end
+  end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.

- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Allow customer-managed policy ARNs in managed_iam_policy.
